### PR TITLE
C make fix build warnings

### DIFF
--- a/qhttpserver/qhttprequest.h
+++ b/qhttpserver/qhttprequest.h
@@ -56,14 +56,14 @@ class QHttpRequest : public QObject
 {
     Q_OBJECT
 
-    Q_PROPERTY(HeaderHash headers    READ headers);
-    Q_PROPERTY(QString remoteAddress READ remoteAddress);
-    Q_PROPERTY(quint16 remotePort    READ remotePort);
-    Q_PROPERTY(QString method        READ method);
-    Q_PROPERTY(QUrl    url           READ url);
-    Q_PROPERTY(QString path          READ path);
-    Q_PROPERTY(QString httpVersion   READ httpVersion);
-    Q_ENUMS(HttpMethod);
+    Q_PROPERTY(HeaderHash headers    READ headers)
+    Q_PROPERTY(QString remoteAddress READ remoteAddress)
+    Q_PROPERTY(quint16 remotePort    READ remotePort)
+    Q_PROPERTY(QString method        READ method)
+    Q_PROPERTY(QUrl    url           READ url)
+    Q_PROPERTY(QString path          READ path)
+    Q_PROPERTY(QString httpVersion   READ httpVersion)
+    Q_ENUMS(HttpMethod)
 
 public:
     virtual ~QHttpRequest();


### PR DESCRIPTION
Building with CMake produces 46 cases of this warning
"beru/qhttpserver/qhttprequest.h:59: warning: extra ';' [-Wpedantic]"
removing these semi-colons removes the warnings from the build.

I was hoping this would have an effect on issue #56, but no luck. Still nice to eliminate the 46 warnings it produces.
