### PR TITLE
Fix for issue 63 - force flickable to return to its bounds

### DIFF
--- a/ui/BookPage.qml
+++ b/ui/BookPage.qml
@@ -94,7 +94,7 @@ Page {
             action: Action {
                 text: i18n.tr("Library")
                 iconName: "back"
-                onTriggered: pageStack.pop()
+                onTriggered: {pageStack.pop(); localBooks.flickable.returnToBounds()}
             }
         }
 


### PR DESCRIPTION
This does the reload of the localBooks in a different way, I think a way that addresses the actual problem (but may not actual fix it). Flickable of localBooks is told to returnToBounds() which pushes all the book covers back up to their original positions.
