### PR TITLE
add UBUNTU_MANIFEST_PATH to cmakelists.txt so that Qtcreator picks it up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-permissive -pedantic -Wa
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(UBUNTU_PROJECT_TYPE "ClickApp" CACHE INTERNAL "Tells QtCreator this is a Click application project")
-
+set(UBUNTU_MANIFEST_PATH "manifest.json.in" CACHE INTERNAL "Tells QtCreator location and name of the manifest file")
 # Standard install paths
 include(GNUInstallDirs)
 include(FindPkgConfig)


### PR DESCRIPTION
After adding this I can build and run beru fine now, and you should be able to select beru from Projects -> Run configuration